### PR TITLE
filter out the rows that do have non-numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,9 @@ export default class LeafletMap extends Visualization {
     const tooltipIdx = getColumnIndex(config, 'tooltip');
     const popupIdx = getColumnIndex(config, 'popup', true);
 
-    const rows = data.rows.map(tableRow => {
+    const rows = data.rows.filter(tableRow => {
+        return !(isNaN(tableRow[latIdx]) || isNaN(tableRow[lngIdx]));
+      }).map(tableRow => {
       const tooltip = tableRow[tooltipIdx];
       const lat = Number(tableRow[latIdx]);
       const lng = Number(tableRow[lngIdx]);


### PR DESCRIPTION
rationale: in some cases, the database query (for example in Cassandra) doesn't allow to
filter out the null values, etc.  In this case current version shows error.

The proposed change just throw away that rows that have non-numbers

P.S. maybe we need to log that decision, need to be discussed